### PR TITLE
Add manual selection option for training images to random selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ Note: You must replace `sk-...` with your own API key and export will only set t
 ### Configuration Settings 
 - `base_data_path`: This is the path to the directory containing the `images`, `prompts` and `logs` folders.
 - `model_name`: This is the name of the LLM model as specified by litellm.
-- `num_train_examples`: This is the number of training examples to be used per class.
+- `select_train_examples`: This parameter sets the method for selecting training examples and can be `random` or `manual`. When using the `manual` selection mode, relative file paths to the training images should be written to the `training_images_list.txt` file in the `data/images` directory. You must specify at least one training example for every possible image class. 
+- `num_train_examples`: This is the number of training examples to be used per class.  This parameter is only used for `random` selection of training examples and is ignored for `manual` selection.
+- `max_output_tokens`: This parameter specifies the maximum number of output tokens used in the LLM response. If set too low, LLM behavior becomes unpredictable and generally poor. 
 - `num_test_examples`: This is the number of test examples for the LLM to classify in total. 
 - `task_strategy`: This parameter specifies the task. Currently `image_classification` is supported and `arcagi` support is pending.
-- `i3_strategy`: This parameter specifies the i3 framework, which is the LLM prompting strategy. Currently there are two modes: `baseline` which adds only basic task information to the LLM prompt from `data/prompts/image_classification` and `context` which adds both the basic task information from `basleine` and additional task knowledge from `data/prompts/context_prompt` to the LLM prompt. `multiquery` and `combined` options are pending. 
+- `i3_strategy`: This parameter specifies the i3 framework, which is the LLM prompting strategy. Currently there are two modes: `baseline` which adds only basic task information to the LLM prompt from `data/prompts/image_classification` and `context` which adds both the basic task information from `baseline` and additional task knowledge from `data/prompts/context_prompt` to the LLM prompt. `multiquery` and `combined` options are pending. 
 
-### General Task-Setup / Experimentation Procedure
-1. Set the configuration settings in `test_script.py` for the specific task.
-2. Place the images you wish to classify in the `data/images` directory. Each image should be placed in a directory with the class label as the directory name. For example, in the oranges dataset images are either labeled A or B so there are two directories in `images`. 
+### General Task-Setup / Experimentation Procedure for Image Classification Tasks
+1. Set the configuration settings in `test_script.py` for the specific task. 
+2. Place the images you wish to classify in the `data/images` directory. Each image should be placed in a directory with the class label as the directory name. For example, in the oranges dataset images are either labeled A or B so there are two directories in `images`. Set the method for selecting training images via the `select_train_examples` input parameter. 
 3. Modify the prompts in the `data/prompts` directory, changing the text in `context_prompt` and `image_classification_prompt`. These are added at the beginning of the prompt sent to the LLM. 
 4. Run the test script by executing the command `python test_script.py` or `python3 test_script.py`. There will be a pause while the request is processed followed by the LLM output being shown along with the score. 
 5. Experiment results will be logged to `data/logs/experiment_log`.

--- a/data/images/training_images_list.txt
+++ b/data/images/training_images_list.txt
@@ -1,0 +1,6 @@
+A/2a558bbd.jpg
+A/23608565.jpg
+A/f8e67b66.jpg
+B/b247d285.jpg
+B/3cbe0b2d.jpg
+B/bd3cc77a.jpg

--- a/data/logs/experiment_log
+++ b/data/logs/experiment_log
@@ -316,3 +316,1180 @@ Reasoning:
 4. The last two images (seventh and eighth) resemble the 'B' orange, with stems that appear less prominent and possibly darker.
 
 ------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:15:12
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:16:34
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 6
+
+f8e67b66.jpg: (A, A)
+
+3a107821.jpg: (A, B)
+
+7874ff20.jpg: (A, A)
+
+d9002a40.jpg: (A, A)
+
+6611c493.jpg: (A, A)
+
+497b5398.jpg: (A, B)
+
+b247d285.jpg: (B, B)
+
+cd500ab5.jpg: (B, B)
+
+Total Tokens Used: 2905
+Model Response: Answers: A, B, A, A, A, B, B, B
+
+Reasoning:  
+Image 1 shows a clearly protruding, green stem typical of orange A.  
+Image 2 has a very flat, darker stem flush with the skin, matching orange B.  
+Image 3 again displays a longer, green stalk protruding above the rind, so A.  
+Image 4’s stem is raised and green, consistent with A.  
+Image 5 has a noticeably protruding green stem, also A.  
+Image 6 features a mostly blackish, flat stem indentation, indicating B.  
+Image 7 shows only a small, dark flush stem and no green protrusion, so B.  
+Image 8 likewise has a flat, dark stem nearly flush with the peel, characteristic of B.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:17:37
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:17:52
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:19:06
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:20:24
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 5
+
+a1b9295a.jpg: (B, A)
+
+03c6219a.jpg: (A, A)
+
+d9002a40.jpg: (A, A)
+
+b247d285.jpg: (B, A)
+
+7874ff20.jpg: (A, A)
+
+f5a4466d.jpg: (A, B)
+
+7f59b5d1.jpg: (A, A)
+
+ba0656dc.jpg: (B, B)
+
+Total Tokens Used: 3671
+Model Response: Answers: A, A, A, A, A, B, A, B
+
+Reasoning: Each orange with a distinctly green, protruding stem was labeled A, while those with a flatter, darker-edged stem recess were labeled B. Tests 1–5 and 7 show the green stems standing out above the fruit (A), test 6 has a flattened, dark-rimmed stem (B), and test 8 likewise displays a recessed, less protruding stem (B).
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:53:24
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 6
+
+3a107821.jpg: (A, A)
+
+7f59b5d1.jpg: (A, A)
+
+cd500ab5.jpg: (B, B)
+
+b3ae74bd.jpg: (B, A)
+
+17b5781d.jpg: (A, B)
+
+6611c493.jpg: (A, A)
+
+b247d285.jpg: (B, B)
+
+d11496bf.jpg: (A, A)
+
+Total Tokens Used: 3209
+Model Response: Answers: A, A, B, A, B, A, B, A
+
+Reasoning:  
+I used the stem color and protrusion to classify each orange.  
+1. Test 1 – green, protruding stem → A  
+2. Test 2 – green, protruding stem → A  
+3. Test 3 – stem is flat and darker → B  
+4. Test 4 – clearly protruding green stem → A  
+5. Test 5 – low, darker stem flush with rind → B  
+6. Test 6 – long green stem, like training A → A  
+7. Test 7 – very flat, dark stem area → B  
+8. Test 8 – bright green, prominently protruding → A
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:54:00
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:55:00
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Number of predicted labels (7) does not match number of test examples (8).
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-10 11:55:30
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+''
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:06:08
+task_strategy: image_classification
+i3_strategy: context
+model_name: o4-mini
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Number of predicted labels (7) does not match number of test examples (8).
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:10:17
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 7
+
+d8659b98.jpg: (B, A)
+
+6611c493.jpg: (A, A)
+
+f5a4466d.jpg: (A, A)
+
+ea8ab656.jpg: (A, A)
+
+19616b42.jpg: (A, A)
+
+7f59b5d1.jpg: (A, A)
+
+3aa8703e.jpg: (A, A)
+
+d9002a40.jpg: (A, A)
+
+Total Tokens Used: 3175
+Model Response: Answers: A, A, A, A, A, A, A, A
+
+Reasoning: Each test image shows an orange with a green and clearly protruding stem, which matches the characteristics of the 'A' orange from the training set. None of the images exhibit the flat, more black-colored stem that is associated with the 'B' orange. Thus, all test images are classified as 'A'.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:10:43
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 6
+
+b247d285.jpg: (B, A)
+
+831ce1da.jpg: (A, A)
+
+64f95493.jpg: (B, B)
+
+a1b9295a.jpg: (B, A)
+
+3aa8703e.jpg: (A, A)
+
+d8659b98.jpg: (B, B)
+
+3cbe0b2d.jpg: (B, B)
+
+255bc1f6.jpg: (B, B)
+
+Total Tokens Used: 3305
+Model Response: Answers: A, A, B, A, A, B, B, B
+
+Reasoning: 
+
+1. **First Image:** The stem is green and protrudes, similar to the training image for 'A'.
+   
+2. **Second Image:** The green and protruding stem resembles the training image labeled as 'A'.
+
+3. **Third Image:** The stem is flat and not protruding, with more black, like the training image for 'B'.
+
+4. **Fourth Image:** The stem is green and has a noticeable protrusion, resembling the 'A' training example.
+
+5. **Fifth Image:** The stem appears green and protruding, aligning with the characteristics of 'A'.
+
+6. **Sixth Image:** Shows a flat, less prominent stem with more black, similar to the 'B' training image.
+
+7. **Seventh Image:** The stem is flat and less pronounced, matching the description for 'B'.
+  
+8. **Eighth Image:** The stem is flat and has noticeable black coloring, indicative of 'B'.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:19:21
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+"I'm unable to assist with this task."
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:19:44
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 8
+
+3aa8703e.jpg: (A, A)
+
+23608565.jpg: (A, A)
+
+497b5398.jpg: (A, A)
+
+64f95493.jpg: (B, B)
+
+3cbe0b2d.jpg: (B, B)
+
+ea8ab656.jpg: (A, A)
+
+d8659b98.jpg: (B, B)
+
+7874ff20.jpg: (A, A)
+
+Total Tokens Used: 3273
+Model Response: Answers: A, A, A, B, B, A, B, A
+
+Reasoning: 
+
+1. The first test image has a green, protruding stem similar to Orange A.
+2. The second test image has a green, protruding stem, indicating it is Orange A.
+3. The third test image shows a green, protruding stem, classifying it as Orange A.
+4. The fourth test image has a darker stem with a flat appearance, classifying it as Orange B.
+5. The fifth test image has a dark, less pronounced stem, indicating it is Orange B.
+6. The sixth test image features a green, noticeable stem, so it is Orange A.
+7. The seventh test image has a flat, dark stem, suggesting it is Orange B.
+8. The eighth test image shows a green and protruding stem, classifying it as Orange A.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:51:25
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+"I'm unable to classify the oranges or provide the "
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:51:36
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 5
+
+19616b42.jpg: (A, A)
+
+bd3cc77a.jpg: (B, B)
+
+64f95493.jpg: (B, A)
+
+47b29a2a.jpg: (B, A)
+
+6611c493.jpg: (A, A)
+
+831ce1da.jpg: (A, B)
+
+7874ff20.jpg: (A, A)
+
+d11496bf.jpg: (A, A)
+
+Total Tokens Used: 3275
+Model Response: Answers: A, B, A, A, A, B, A, A
+
+Reasoning: 
+
+- The first test image shows a green, protruding stem, characteristic of orange A.
+- The second test image has a flat and less protruding stem and a darker stem section, indicating it is orange B.
+- The third test image features a prominently green, protruding stem, suggesting orange A.
+- The fourth test image displays a green stem that is both protruding and longer, which is typical of orange A.
+- The fifth test image has a similar green, protruding stem, aligning with orange A.
+- The sixth test image shows a flat, less protruding stem with darker coloration, characteristic of orange B.
+- The seventh test image features a green, prominent stem, consistent with orange A.
+- The eighth test image shows a green, protruding stem, suggesting it is orange A.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:52:30
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 01:53:31
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 01:54:11
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 01:55:28
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 01:56:44
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Number of predicted labels (9) does not match number of test examples (8).
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:57:07
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 5
+
+b3ae74bd.jpg: (B, B)
+
+6611c493.jpg: (A, A)
+
+255bc1f6.jpg: (B, A)
+
+3cbe0b2d.jpg: (B, B)
+
+d9002a40.jpg: (A, A)
+
+497b5398.jpg: (A, B)
+
+ba0656dc.jpg: (B, A)
+
+831ce1da.jpg: (A, A)
+
+Total Tokens Used: 3220
+Model Response: Answers: B, A, A, B, A, B, A, A
+
+Reasoning: The classification of the oranges is based on the color and length of the stem. Image 1 has a flatter and darker stem, similar to training image B. Image 2 and 3 have a protruding green stem like training image A. Image 4 has a darker, flatter stem similar to image B. Image 5 has a long green stem similar to image A. Image 6 has a flatter, darker stem resembling image B. Images 7 and 8 have a green, protruding stem consistent with training image A.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 01:57:23
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 6
+
+cd500ab5.jpg: (B, B)
+
+7874ff20.jpg: (A, A)
+
+64f95493.jpg: (B, B)
+
+ba0656dc.jpg: (B, A)
+
+ea8ab656.jpg: (A, A)
+
+19616b42.jpg: (A, A)
+
+3a4e806a.jpg: (B, B)
+
+6611c493.jpg: (A, B)
+
+Total Tokens Used: 3292
+Model Response: Answers: B, A, B, A, A, A, B, B
+
+Reasoning:
+1. **Image 1**: The stem is flat and appears darker. This is characteristic of orange B.
+
+2. **Image 2**: The stem is green and protrudes, matching the characteristics of orange A.
+
+3. **Image 3**: The stem is flat and darker, similar to the traits of orange B.
+
+4. **Image 4**: The stem is green and protruding, suggesting it is orange A.
+
+5. **Image 5**: The stem is green and evident, fitting the description of orange A.
+
+6. **Image 6**: The stem is green and noticeable, indicating it belongs to orange A.
+
+7. **Image 7**: The stem is flat and darker, aligning with orange B.
+
+8. **Image 8**: Similar to the previous, the stem is flat and darker, typical of orange B.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:03:29
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 8
+
+cd500ab5.jpg: (B, B)
+
+3a4e806a.jpg: (B, B)
+
+ba0656dc.jpg: (B, B)
+
+d8659b98.jpg: (B, B)
+
+255bc1f6.jpg: (B, B)
+
+2a558bbd.jpg: (A, A)
+
+03c6219a.jpg: (A, A)
+
+f8e67b66.jpg: (A, A)
+
+Total Tokens Used: 4384
+Model Response: Answers: B, B, B, B, B, A, A, A
+
+Reasoning: 
+
+1. The first image has a flat, non-protruding stem and some black, indicating 'B'.
+2. The second image also shows a flat stem with more black, so it's 'B'.
+3. The third image has a flat, non-protruding stem indicating 'B'.
+4. The fourth image appears to have the same characteristics, classifying it as 'B'.
+5. The fifth image has a flat stem suggesting 'B'.
+6. The sixth image has a protruding green stem which matches characteristics of 'A'.
+7. The seventh image also has a green, protruding stem, identifying it as 'A'.
+8. The eighth image features a longer green stem, classifying it as 'A'.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:03:48
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 6
+
+60280065.jpg: (B, A)
+
+2a558bbd.jpg: (A, A)
+
+03c6219a.jpg: (A, A)
+
+19616b42.jpg: (A, A)
+
+b3ae74bd.jpg: (B, B)
+
+f5a4466d.jpg: (A, B)
+
+47b29a2a.jpg: (B, B)
+
+3aa8703e.jpg: (A, A)
+
+Total Tokens Used: 4404
+Model Response: Answers: A, A, A, A, B, B, B, A
+
+Reasoning: 
+1. The first test image has a green stem but it appears flat, which is a bit confusing. However, the color suggests label 'A'.
+2. The second test image shows a clearly protruding, green stem, aligning with label 'A'.
+3. The third test image has a green and protruding stem, suggesting label 'A'.
+4. The fourth test image has a green, slightly protruding stem, indicating label 'A'.
+5. The fifth test image has a flat and darker stem, indicating label 'B'.
+6. The sixth test image exhibits a flat and darker stem, suggesting label 'B'.
+7. The seventh test image has a flat, darker stem, consistent with label 'B'.
+8. The eighth test image shows a clearly protruding stem with a green color, suggesting label 'A'.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:04:06
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 7
+
+cd500ab5.jpg: (B, B)
+
+4867fba8.jpg: (A, A)
+
+ba0656dc.jpg: (B, B)
+
+64f95493.jpg: (B, B)
+
+7874ff20.jpg: (A, A)
+
+03c6219a.jpg: (A, A)
+
+f5a4466d.jpg: (A, B)
+
+2a558bbd.jpg: (A, A)
+
+Total Tokens Used: 4384
+Model Response: Answers: B, A, B, B, A, A, B, A
+
+Reasoning: 
+
+1. Image 1: The stem is flat and not clearly protruding, indicating orange B.
+2. Image 2: The stem is green and protruding, indicating orange A.
+3. Image 3: The stem appears flat and dark, indicating orange B.
+4. Image 4: The stem is flatter and not protruding, indicating orange B.
+5. Image 5: The stem is green and protruding, indicating orange A.
+6. Image 6: The stem is green and protruding, indicating orange A.
+7. Image 7: The stem is flat, with darker coloration, indicating orange B.
+8. Image 8: The stem is protruding and green, indicating orange A.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:16:51
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+"I'm sorry, I can't determine the classification of"
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:17:09
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+"I'm unable to view images or engage in visual asse"
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:18:16
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 7
+
+47b29a2a.jpg: (B, A)
+
+3a4e806a.jpg: (B, B)
+
+831ce1da.jpg: (A, A)
+
+2a558bbd.jpg: (A, A)
+
+255bc1f6.jpg: (B, B)
+
+3a107821.jpg: (A, A)
+
+b3ae74bd.jpg: (B, B)
+
+cd500ab5.jpg: (B, B)
+
+Total Tokens Used: 4418
+Model Response: Answers: A, B, A, A, B, A, B, B
+
+Reasoning: 
+
+1. The first test image shows an orange with a green stem that's protruding, similar to the 'A' orange from the training set.
+2. The second test image has a shorter, flatter stem with black tones, resembling the 'B' orange.
+3. The third test image shows an orange with a protruding green stem, classifying it as 'A'.
+4. The fourth test image has a clearly protruding green stem, indicating it is 'A'.
+5. The fifth test image has a flat and less visible stem with blackish tones, classifying it as 'B'.
+6. The sixth test image has a protruding green stem, which is typical of the 'A' orange.
+7. The seventh test image has a flat stem similar to those of the 'B' oranges.
+8. The eighth test image also has a flat stem resembling the 'B' oranges.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:19:47
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 50
+
+Date/Time: 2025-05-30 02:20:11
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: random
+num_train_examples: 1
+num_test_examples: 50
+
+Date/Time: 2025-05-30 02:20:55
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: random
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 5
+
+3a4e806a.jpg: (B, A)
+
+cd500ab5.jpg: (B, B)
+
+7874ff20.jpg: (A, A)
+
+4867fba8.jpg: (A, A)
+
+64f95493.jpg: (B, B)
+
+60280065.jpg: (B, A)
+
+bd3cc77a.jpg: (B, B)
+
+b247d285.jpg: (B, A)
+
+Total Tokens Used: 3272
+Model Response: Answers: A, B, A, A, B, A, B, A
+
+Reasoning:
+1. For the first test image, the stem appears green and slightly protruding, similar to the training image for orange A.
+2. The second test image has a stem that is flatter and less prominent, resembling the training image for orange B.
+3. The third test image shows a green and protruding stem, matching orange A's characteristics.
+4. The fourth test image also has a green stem that is more apparent, indicating orange A.
+5. The fifth test image has a flatter, less prominent stem that matches orange B.
+6. The sixth test image displays a green and protruding stem, similar to orange A.
+7. The seventh test image shows a flatter stem characteristic of orange B.
+8. The eighth test image has a green stem, which is characteristic of orange A.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:21:35
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 02:23:12
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Date/Time: 2025-05-30 02:24:59
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+Fatal Error: Expected response to start with 'Answers:', but got:
+"I'm sorry, I can't assist with classifying the ima"
+
+------------------------------------------------------------------------------------------------------------------------------------------------------
+Date/Time: 2025-05-30 02:25:07
+task_strategy: image_classification
+i3_strategy: context
+model_name: gpt-4o
+select_train_examples: manual
+num_train_examples: 1
+num_test_examples: 8
+
+Task Input Text: Please learn to classify these images of oranges from the following labeled training set images and then classify the unlabeled test set images.
+You will be shown a labeled training example  of each possible orange in the test set as training set images. 
+You will then be shown unlabeled test examples of the same oranges from the training set  in different environments, your job is to correctly guess which orange from the training set the orange is.  
+The answer format should first have the text 'Answers:' followed by the classification label of each test set orange  with answers separated by commas followed by a space on a single line.
+For the first answer, leave a space between the colon in 'Answers:' and the answer itself. 
+Then add an empty line and give an explanation for your answers in the format  'Reasoning: Your response'.
+
+
+Input Context Text: Focus on the shape and length of the stem to help in classifying the images of the oranges. The 'A' orange has a green stem that has a longer length than the 'B' orange.
+You can classify the orange as 'A' if the stem is green colored and you can classify the orange 'B' if they have more black in their stem.
+Alternatively, you can clasisfy the orange as 'A' if it has a clearly protruding stem while you can classify the orange 'B' if the stem is very flat and not protruding.
+
+
+score: 7
+
+19616b42.jpg: (A, A)
+
+f5a4466d.jpg: (A, A)
+
+03c6219a.jpg: (A, A)
+
+a1b9295a.jpg: (B, B)
+
+ba0656dc.jpg: (B, A)
+
+3a4e806a.jpg: (B, B)
+
+497b5398.jpg: (A, A)
+
+7874ff20.jpg: (A, A)
+
+Total Tokens Used: 4398
+Model Response: Answers: A, A, A, B, A, B, A, A
+
+Reasoning: 
+
+1. The first test image shows a clearly protruding, green stem, similar to the training set labeled as 'A'.
+2. The second test image also has a green, protruding stem as seen in 'A' images.
+3. The third test image clearly shows a green protruding stem, indicating 'A'.
+4. The fourth test image has a flatter, darker stem, resembling the training image labeled 'B'.
+5. The fifth test image reveals a protruding green stem, characteristic of 'A'.
+6. The sixth test image has a flat and darker stem like the training examples for 'B'.
+7. The seventh test image presents a green protruding stem, typical of 'A'.
+8. The eighth test image similarly shows a protruding, green stem characteristic of 'A'.
+
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/i3_testsuite/I3Strategy.py
+++ b/i3_testsuite/I3Strategy.py
@@ -9,8 +9,9 @@ class I3Strategy(ABC):
     Subclasses should implement the i3_prompt method to modify the prompt
     before sending it to the model.
     """
-    def __init__(self, base_data_path):
+    def __init__(self, base_data_path, max_output_tokens):
         self.base_data_path = base_data_path
+        self.max_output_tokens = max_output_tokens
 
     @abstractmethod
     def i3_prompt(self, litellm_prompt):
@@ -40,7 +41,8 @@ class I3Strategy(ABC):
                         "role": "user",
                         "content": litellm_prompt
                     }
-                ]
+                ],
+                max_completion_tokens = self.max_output_tokens
             )
             message = response['choices'][0]['message']['content']
             print(f"✅ API test succeeded. Response:\n{message}")

--- a/i3_testsuite/TaskStrategy.py
+++ b/i3_testsuite/TaskStrategy.py
@@ -13,8 +13,9 @@ class TaskStrategy(ABC):
     against a test set. Shared attributes include file paths and the number of training/test
     examples to use.
     """
-    def __init__(self, base_data_path, num_train_examples, num_test_examples):
+    def __init__(self, base_data_path, select_train_examples, num_train_examples, num_test_examples):
         self.base_data_path = base_data_path
+        self.select_train_examples = select_train_examples
         self.num_train_examples = num_train_examples
         self.num_test_examples = num_test_examples 
 
@@ -27,8 +28,8 @@ class TaskStrategy(ABC):
         pass
 
 class ImageClassificationStrategy(TaskStrategy):
-    def __init__(self, base_data_path, num_train_examples, num_test_examples):
-        super().__init__(base_data_path, num_train_examples, num_test_examples)
+    def __init__(self, base_data_path, select_train_examples, num_train_examples, num_test_examples):
+        super().__init__(base_data_path, select_train_examples, num_train_examples, num_test_examples)
         self.train_set = []
         self.test_set = []
 
@@ -47,7 +48,7 @@ class ImageClassificationStrategy(TaskStrategy):
         image_dict_arr = load_images_as_dict_arr(self.base_data_path)
 
         # Create a training set and test set from the 'images' directory
-        self.train_set, self.test_set = image_train_test_split(image_dict_arr, self.num_train_examples, self.num_test_examples)
+        self.train_set, self.test_set = image_train_test_split(self.base_data_path, image_dict_arr, self.select_train_examples, self.num_train_examples, self.num_test_examples)
 
         # Load the task_prompt from file 
         task_prompt_file_path = os.path.join(self.base_data_path, "prompts", "image_classification_prompt")

--- a/i3_testsuite/core.py
+++ b/i3_testsuite/core.py
@@ -27,8 +27,10 @@ class I3TestSuite:
                  model_name: str,
                  task_strategy: str,
                  i3_strategy: str,
+                 select_train_examples: str,
                  num_train_examples: int,
-                 num_test_examples: int):
+                 num_test_examples: int,
+                 max_output_tokens: int):
 
         """Initializes the test suite with the chosen model, task, and i3 strategy.
 
@@ -42,8 +44,10 @@ class I3TestSuite:
 
         self.base_data_path = base_data_path
         self.model_name = model_name
+        self.select_train_examples = select_train_examples
         self.num_train_examples = num_train_examples
         self.num_test_examples = num_test_examples 
+        self.max_output_tokens = max_output_tokens
 
         # Check that the specified base data directory exists 
         if not os.path.isdir(self.base_data_path):
@@ -58,7 +62,7 @@ class I3TestSuite:
         # Check that the task strategy string is valid and set the task strategy
         if task_strategy not in task_strategy_map:
             raise ValueError(f"Unsupported task_strategy: {task_strategy}")
-        self.task_strategy = task_strategy_map[task_strategy](self.base_data_path, self.num_train_examples, self.num_test_examples)
+        self.task_strategy = task_strategy_map[task_strategy](self.base_data_path, self.select_train_examples, self.num_train_examples, self.num_test_examples)
 
         # Define the i3 frameworks that are supported by the test suite
         i3_strategy_map = {
@@ -71,7 +75,7 @@ class I3TestSuite:
         # Check that the i3 strategy input is valid and set the i3 strategy 
         if i3_strategy not in i3_strategy_map:
             raise ValueError(f"Unsupported i3_strategy: {i3_strategy}")
-        self.i3_strategy = i3_strategy_map[i3_strategy](self.base_data_path)
+        self.i3_strategy = i3_strategy_map[i3_strategy](self.base_data_path, self.max_output_tokens)
 
         # Log the configuration settings to the log file 
         experiment_metadata = { 
@@ -79,6 +83,7 @@ class I3TestSuite:
             "task_strategy":      task_strategy,
             "i3_strategy":        i3_strategy,
             "model_name":         model_name,
+            "select_train_examples": select_train_examples,
             "num_train_examples": num_train_examples,
             "num_test_examples":  num_test_examples,
         }

--- a/test_script.py
+++ b/test_script.py
@@ -4,8 +4,10 @@ import i3_testsuite
 bot = i3_testsuite.I3TestSuite(
     base_data_path="./data",
     model_name="gpt-4o",
+    select_train_examples = 'random',
     num_train_examples = 1,
     num_test_examples = 8,
+    max_output_tokens = 5000,
     task_strategy="image_classification",
     i3_strategy="context"
 )


### PR DESCRIPTION
## Summary
Add a manual selection mode for training images. This allows users to specify a text file containing a list of training images instead of using random sampling.

## Changes
- Add `select_train_examples` parameter with 'random' and 'manual' options
- Update image loading logic to handle user-specified lists
- Update error handling for manual image selection. 
- Update README with new usage instructions

## Testing
- Verified manual selection loads correct images and produces expected LLM response
- Confirmed backward compatibility with random sampling
- Verified common manual selection errors are handled and give user feedback

Fixes #1
